### PR TITLE
GHC 7.10 requires FlexibleContexts

### DIFF
--- a/Data/BloomFilter/Mutable.hs
+++ b/Data/BloomFilter/Mutable.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, CPP, Rank2Types,
-    TypeOperators #-}
+    TypeOperators, FlexibleContexts #-}
 
 -- |
 -- Module: Data.BloomFilter.Mutable


### PR DESCRIPTION
Even for inferred types as is the case here.