### PR TITLE
Adding unsafeCreate to allow for deserialization of Bloom filters.

### DIFF
--- a/Data/BloomFilter.hs
+++ b/Data/BloomFilter.hs
@@ -70,6 +70,7 @@ module Data.BloomFilter
 
     -- | The raw bit array used by the immutable 'Bloom' type.
     , bitArray
+    , unsafeCreate
     ) where
 
 import Control.Monad (liftM, forM_)

--- a/Data/BloomFilter.hs
+++ b/Data/BloomFilter.hs
@@ -70,7 +70,8 @@ module Data.BloomFilter
 
     -- | The raw bit array used by the immutable 'Bloom' type.
     , bitArray
-    , unsafeCreate
+    , serialize
+    , unsafeDeserialize
     ) where
 
 import Control.Monad (liftM, forM_)
@@ -85,6 +86,9 @@ import qualified Data.BloomFilter.Mutable as MB
 import qualified Data.BloomFilter.Mutable.Internal as MB
 import Data.BloomFilter.Mutable.Internal (Hash, MBloom)
 import Data.Word (Word32)
+
+import Data.Serialize
+import Data.ByteString (ByteString)
 
 import Prelude hiding (elem, length, notElem,
                        (/), (*), div, divMod, mod, rem)
@@ -106,17 +110,6 @@ instance NFData (Bloom a) where
 
 logBitsInHash :: Int
 logBitsInHash = 5 -- logPower2 bitsInHash
-
--- | Create an immutable Bloom filter from the underlying bit array.
--- This creates a valid Bloom filter if and only if the arguments passed to
--- @unsafeCreate@ are the same as those that were passed to @create@ or @new@ for the original Bloom filter.
-unsafeCreate :: (a -> [Hash])        -- ^ family of hash functions to use
-             -> Int                  -- ^ number of bits in filter
-             -> UArray Int Hash      -- ^ Underlying bit array.
-             -> Bloom a
-unsafeCreate hash numBits bits =
-  (create hash numBits (\_ -> return ())) { bitArray = bits }
-
 
 -- | Create an immutable Bloom filter, using the given setup function
 -- which executes in the 'ST' monad.
@@ -331,6 +324,21 @@ logPower2 :: Int -> Int
 logPower2 k = go 0 k
     where go j 1 = j
           go j n = go (j+1) (n `shiftR` 1)
+
+serialize :: Bloom a -> ByteString
+serialize bloom = encode (shift bloom, mask bloom, bitArray bloom)
+
+unsafeDeserialize :: (a -> [Hash]) -> ByteString -> Either String (Bloom a)
+unsafeDeserialize hashes bs =
+  case decode bs of
+    Left err -> Left err
+    Right (shift, mask, bitArray) -> Right $ B
+      { hashes = hashes
+      , shift = shift
+      , mask = mask
+      , bitArray = bitArray
+      }
+
 
 -- $overview
 --

--- a/Data/BloomFilter.hs
+++ b/Data/BloomFilter.hs
@@ -106,6 +106,17 @@ instance NFData (Bloom a) where
 logBitsInHash :: Int
 logBitsInHash = 5 -- logPower2 bitsInHash
 
+-- | Create an immutable Bloom filter from the underlying bit array.
+-- This creates a valid Bloom filter if and only if the arguments passed to
+-- @unsafeCreate@ are the same as those that were passed to @create@ or @new@ for the original Bloom filter.
+unsafeCreate :: (a -> [Hash])        -- ^ family of hash functions to use
+             -> Int                  -- ^ number of bits in filter
+             -> UArray Int Hash      -- ^ Underlying bit array.
+             -> Bloom a
+unsafeCreate hash numBits bits =
+  (create hash numBits (\_ -> return ())) { bitArray = bits }
+
+
 -- | Create an immutable Bloom filter, using the given setup function
 -- which executes in the 'ST' monad.
 --

--- a/bloomfilter.cabal
+++ b/bloomfilter.cabal
@@ -20,6 +20,7 @@ library
     array,
     base       >= 4.4 && < 5,
     bytestring >= 0.9,
+    cereal >= 0.4,
     deepseq
   exposed-modules:  Data.BloomFilter
                     Data.BloomFilter.Easy


### PR DESCRIPTION
This is still WIP, but would you accept this contribution? 

I need to be able to deserialize bloom filters from disk, and there is currently no way to do that.

An alternate route is to provide `Binary` instances or have a dependency on `cereal`.

Thoughts? Issue #3 is fairly important I think.
