### PR TITLE
Change notElem docs mistake

### DIFF
--- a/Data/BloomFilter.hs
+++ b/Data/BloomFilter.hs
@@ -252,7 +252,7 @@ insertList elts = modify $ \mb -> mapM_ (MB.insert mb) elts
 
 -- | Query an immutable Bloom filter for non-membership.  If the value
 -- /is/ present, return @False@.  If the value is not present, there
--- is /still/ some possibility that @True@ will be returned.
+-- is /still/ some possibility that @False@ will be returned.
 notElem :: a -> Bloom a -> Bool
 notElem elt ub = any test (hashesU ub elt)
   where test (off :* bit) = (bitArray ub `unsafeAt` off) .&. (1 `shiftL` bit) == 0


### PR DESCRIPTION
`notElem` may return True or False for values not present in the filter
so both True and False could make sense here but False makes more
sense given the emphasis on "still" and for the parallelism with `elem`.

Fixes #17 