### PR TITLE
Adapt FastShift instances for Word32 to ghc-9.4.x.

### DIFF
--- a/Data/BloomFilter/Util.hs
+++ b/Data/BloomFilter/Util.hs
@@ -40,10 +40,10 @@ class FastShift a where
 
 instance FastShift Word32 where
     {-# INLINE shiftL #-}
-    shiftL (W32# x#) (I# i#) = W32# (x# `uncheckedShiftL#` i#)
+    shiftL (W32# x#) (I# i#) = W32# (x# `uncheckedShiftLWord32#` i#)
 
     {-# INLINE shiftR #-}
-    shiftR (W32# x#) (I# i#) = W32# (x# `uncheckedShiftRL#` i#)
+    shiftR (W32# x#) (I# i#) = W32# (x# `uncheckedShiftRLWord32#` i#)
 
 instance FastShift Word64 where
     {-# INLINE shiftL #-}


### PR DESCRIPTION
ghc-9.4.x changed the type of Word32. This trivial patch fixes the build with the latest version.